### PR TITLE
Supporting OLMo2

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -157,6 +157,7 @@ class HookedTransformer(HookedRootModule):
                 add_bos_token = self.cfg.original_architecture not in [
                     "OlmoForCausalLM",
                     "OlmoeForCausalLM",
+                    "Olmo2ForCausalLM",
                 ]
                 self.set_tokenizer(
                     AutoTokenizer.from_pretrained(
@@ -695,6 +696,7 @@ class HookedTransformer(HookedRootModule):
         if self.cfg.original_architecture not in [
             "OlmoForCausalLM",
             "OlmoeForCausalLM",
+            "Olmo2ForCausalLM",
         ]:
             tokenizer_with_bos = utils.get_tokenizer_with_bos(tokenizer)
         else:
@@ -1781,13 +1783,17 @@ class HookedTransformer(HookedRootModule):
         W_out. This is done by subtracting the mean of the weights from the weights themselves. This
         is done in-place. See fold_layer_norm for more details.
         """
-        state_dict["embed.W_E"] = state_dict["embed.W_E"] - state_dict["embed.W_E"].mean(
-            -1, keepdim=True
-        )
-        if self.cfg.positional_embedding_type != "rotary":
-            state_dict["pos_embed.W_pos"] = state_dict["pos_embed.W_pos"] - state_dict[
-                "pos_embed.W_pos"
-            ].mean(-1, keepdim=True)
+        if self.cfg.original_architecture == "Olmo2ForCausalLM":
+            print("Not centering embedding weights for Olmo2ForCausalLM")
+            pass # should not because input of attn of 1st layer is not normed
+        else:
+            state_dict["embed.W_E"] = state_dict["embed.W_E"] - state_dict["embed.W_E"].mean(
+                -1, keepdim=True
+            )
+            if self.cfg.positional_embedding_type != "rotary":
+                state_dict["pos_embed.W_pos"] = state_dict["pos_embed.W_pos"] - state_dict[
+                    "pos_embed.W_pos"
+                ].mean(-1, keepdim=True)
         for l in range(self.cfg.n_layers):
             state_dict[f"blocks.{l}.attn.W_O"] = state_dict[f"blocks.{l}.attn.W_O"] - state_dict[
                 f"blocks.{l}.attn.W_O"

--- a/transformer_lens/components/abstract_attention.py
+++ b/transformer_lens/components/abstract_attention.py
@@ -141,9 +141,10 @@ class AbstractAttention(ABC, nn.Module):
             # will be overwritten by the child T5Attention class
             self.has_relative_attention_bias = False
 
-        if self.cfg.original_architecture == "OlmoeForCausalLM":
-            self.q_norm = RMSNorm(cfg, cfg.d_model)
-            self.k_norm = RMSNorm(cfg, cfg.d_head * cfg.n_key_value_heads)
+        if self.cfg.original_architecture == "OlmoeForCausalLM" or self.cfg.original_architecture == "Olmo2ForCausalLM":
+            self.q_norm = RMSNorm(self.cfg, self.cfg.d_model)
+            k_norm_dim = self.cfg.d_model if self.cfg.original_architecture == "Olmo2ForCausalLM" else self.cfg.d_head * self.cfg.n_key_value_heads
+            self.k_norm = RMSNorm(self.cfg, k_norm_dim)
 
     @property
     def OV(self) -> FactoredMatrix:
@@ -201,7 +202,7 @@ class AbstractAttention(ABC, nn.Module):
         q, k, v = self.calculate_qkv_matrices(query_input, key_input, value_input)
 
         # OLMoE uses QK-norm.
-        if self.cfg.original_architecture == "OlmoeForCausalLM":
+        if self.cfg.original_architecture == "OlmoeForCausalLM" or self.cfg.original_architecture == "Olmo2ForCausalLM":
             q = einops.rearrange(
                 self.q_norm(
                     einops.rearrange(

--- a/transformer_lens/pretrained/weight_conversions/__init__.py
+++ b/transformer_lens/pretrained/weight_conversions/__init__.py
@@ -20,3 +20,4 @@ from .t5 import convert_t5_weights
 from .neel_solu_old import convert_neel_solu_old_weights
 from .olmo import convert_olmo_weights
 from .olmoe import convert_olmoe_weights
+from .olmo2 import convert_olmo2_weights

--- a/transformer_lens/pretrained/weight_conversions/olmo2.py
+++ b/transformer_lens/pretrained/weight_conversions/olmo2.py
@@ -1,0 +1,60 @@
+import einops
+import torch
+
+from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
+from transformers.models.olmo2.modeling_olmo2 import Olmo2ForCausalLM, Olmo2DecoderLayer
+
+def convert_olmo2_weights(olmo2:Olmo2ForCausalLM, cfg: HookedTransformerConfig):
+    state_dict = {}
+
+    assert cfg.d_mlp is not None
+
+    state_dict["embed.W_E"] = olmo2.model.embed_tokens.weight
+
+    for l in range(cfg.n_layers):
+        olmo2_layer:Olmo2DecoderLayer = olmo2.model.layers[l]
+
+        W_Q = olmo2_layer.self_attn.q_proj.weight
+        W_K = olmo2_layer.self_attn.k_proj.weight
+        W_V = olmo2_layer.self_attn.v_proj.weight
+        W_Q = einops.rearrange(W_Q, "(n h) m->n m h", n=cfg.n_heads)
+        W_K = einops.rearrange(W_K, "(n h) m->n m h", n=cfg.n_heads)
+        W_V = einops.rearrange(W_V, "(n h) m->n m h", n=cfg.n_heads)
+        state_dict[f"blocks.{l}.attn.W_Q"] = W_Q
+        state_dict[f"blocks.{l}.attn.W_K"] = W_K
+        state_dict[f"blocks.{l}.attn.W_V"] = W_V
+        state_dict[f"blocks.{l}.attn.q_norm.w"] = olmo2_layer.self_attn.q_norm.weight
+        state_dict[f"blocks.{l}.attn.k_norm.w"] = olmo2_layer.self_attn.k_norm.weight
+
+        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+        )
+        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(
+            cfg.n_heads, cfg.d_head, dtype=cfg.dtype
+        )
+
+        W_O = olmo2_layer.self_attn.o_proj.weight
+        W_O = einops.rearrange(W_O, "m (n h)->n h m", n=cfg.n_heads)
+        state_dict[f"blocks.{l}.attn.W_O"] = W_O
+
+        state_dict[f"blocks.{l}.attn.b_O"] = torch.zeros(cfg.d_model, dtype=cfg.dtype)
+
+        state_dict[f"blocks.{l}.ln1.w"] = olmo2_layer.post_attention_layernorm.weight
+
+        state_dict[f"blocks.{l}.mlp.W_in"] = olmo2_layer.mlp.up_proj.weight.T
+        state_dict[f"blocks.{l}.mlp.W_gate"] = olmo2_layer.mlp.gate_proj.weight.T
+        state_dict[f"blocks.{l}.mlp.b_in"] = torch.zeros(cfg.d_mlp, dtype=cfg.dtype)
+
+        state_dict[f"blocks.{l}.mlp.W_out"] = olmo2_layer.mlp.down_proj.weight.T
+        state_dict[f"blocks.{l}.mlp.b_out"] = torch.zeros(cfg.d_model, dtype=cfg.dtype)
+
+        state_dict[f"blocks.{l}.ln2.w"] = olmo2_layer.post_feedforward_layernorm.weight
+
+
+    state_dict["ln_final.w"] = olmo2.model.norm.weight
+
+    state_dict["unembed.W_U"] = olmo2.lm_head.weight.T
+    state_dict["unembed.b_U"] = torch.zeros(cfg.d_vocab, dtype=cfg.dtype)
+
+    return state_dict


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Supporting OLMo2 following commits regarding OLMoe. 

## Question
I wonder if I missed anything. I see that the logits of my implementation do not match those from the hf implementation. Review and help would be so much appreciated.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->