### PR TITLE
Fix to OLMo 2 normalization

### DIFF
--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -279,7 +279,10 @@ OFFICIAL_MODEL_NAMES = [
     "allenai/OLMoE-1B-7B-0924",
     "allenai/OLMoE-1B-7B-0924-SFT",
     "allenai/OLMoE-1B-7B-0924-Instruct",
+    "allenai/OLMo-2-0425-1B",
+    "allenai/OLMo-2-0425-1B-SFT",
     "allenai/OLMo-2-1124-7B",
+    "allenai/OLMo-2-1124-7B-SFT",
 ]
 """Official model names for models on HuggingFace."""
 
@@ -1616,7 +1619,25 @@ def convert_hf_model_config(model_name: str, **kwargs: Any):
             "positional_embedding_type": "rotary",
             "gated_mlp": True,
         }
-    elif official_model_name == "allenai/OLMo-2-1124-7B":
+    elif official_model_name.startswith("allenai/OLMo-2-0425-1B"):
+        cfg_dict = {
+            "d_model": 2048,
+            "d_head": 128,
+            "n_heads": 16,
+            "d_mlp": 8192,
+            "n_layers": 16,
+            "n_ctx": 4096,
+            "eps": 1e-06,
+            "d_vocab": 100352,
+            "act_fn": "silu",
+            "initializer_range": 0.02,
+            "normalization_type": "RMS",
+            "rotary_base": 500000.0,
+            "attn_types": ["global"] * 16,
+            "positional_embedding_type": "rotary",
+            "gated_mlp": True,
+        }
+    elif official_model_name.startswith("allenai/OLMo-2-1124-7B"):
         cfg_dict = {
             "d_model": 4096,
             "d_head": 128,

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1649,7 +1649,7 @@ def convert_hf_model_config(model_name: str, **kwargs: Any):
             "d_vocab": 100352,
             "act_fn": "silu",
             "initializer_range": 0.02,
-            "normalization_type": "RMSPre",
+            "normalization_type": "RMS",
             "rotary_base": 500000.0,
             "attn_types": ["global"] * 32,
             "positional_embedding_type": "rotary",

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -281,8 +281,12 @@ OFFICIAL_MODEL_NAMES = [
     "allenai/OLMoE-1B-7B-0924-Instruct",
     "allenai/OLMo-2-0425-1B",
     "allenai/OLMo-2-0425-1B-SFT",
+    "allenai/OLMo-2-0425-1B-DPO",
+    "allenai/OLMo-2-0425-1B-Instruct",
     "allenai/OLMo-2-1124-7B",
     "allenai/OLMo-2-1124-7B-SFT",
+    "allenai/OLMo-2-1124-7B-DPO",
+    "allenai/OLMo-2-1124-7B-Instruct",
 ]
 """Official model names for models on HuggingFace."""
 


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Hi @jonasrohw (cc: @Ja1Zhou), thanks for working on compatibility for OLMo!

This PR implements a fix and support for OLMo 2:

- A fix to the normalization used by OLMo 2 models [here](https://github.com/jonasrohw/TransformerLens/blob/9032fe7c7e1ed2d14e818147a5b493487e886712/transformer_lens/loading_from_pretrained.py#L1631). This is currently listed as `RMSPre`, but OLMo 2 models applies RMS norm to the outputs of the attention and MLP modules.
- Support for the 1B models and instruct model variants, as referenced [here](https://github.com/jonasrohw/TransformerLens/pull/2#issuecomment-2748181368). 

Here is a simple script I used to check equivalence of the logits and outputs between the huggingface and transformer lens models.

Script:
```python
#!/usr/bin/env python

import torch
from transformers import AutoTokenizer, AutoModelForCausalLM
from transformer_lens import HookedTransformer

# Configuration
raw_prompt = "When John and Mary went to the shops, John gave the bag to"
model_name = "allenai/OLMo-2-0425-1B-Instruct"
instruct_flags = ["instruct", "sft", "dpo",]
is_instruct = any(indicator in model_name.lower() for indicator in instruct_flags)
max_new_tokens = 1

def prepare_prompt(raw_prompt, tokenizer, is_instruct):
    """Prepare prompt based on whether model is instruct or not."""
    if is_instruct:
        # For instruct models, format as a conversation
        messages = [{"role": "user", "content": raw_prompt}]
        return tokenizer.apply_chat_template(
            messages, 
            tokenize=False, 
            add_generation_prompt=True
        )
    else:
        # For base models, use raw prompt
        return raw_prompt

# Load HuggingFace Transformers model
print("Loading HuggingFace Transformers model...")
hf_tokenizer = AutoTokenizer.from_pretrained(model_name)
hf_model = AutoModelForCausalLM.from_pretrained(model_name)

# Prepare prompt and tokenize for HuggingFace model
prompt = prepare_prompt(raw_prompt, hf_tokenizer, is_instruct)
print(repr(prompt))
hf_inputs = hf_tokenizer(prompt, return_tensors="pt", add_special_tokens=False)

# Run inference with HuggingFace model
print("Running inference with HuggingFace model...")
with torch.inference_mode():
    hf_logits = hf_model(**hf_inputs).logits[:, -1, :]

hf_next_token = hf_tokenizer.decode(hf_logits.argmax(dim=-1)[0])
print(f"HuggingFace model next token: {repr(hf_next_token)}")

# Load Transformer Lens model
print("\nLoading Transformer Lens model...")
tl_model = HookedTransformer.from_pretrained_no_processing(model_name, device='cpu')
tl_tokenizer = tl_model.tokenizer

# Prepare prompt and tokenize for Transformer Lens model
prompt = prepare_prompt(raw_prompt, tl_tokenizer, is_instruct)
print(repr(prompt))
tl_inputs = tl_tokenizer(prompt, return_tensors="pt", add_special_tokens=False).input_ids

# Run inference with Transformer Lens model
print("Running inference with Transformer Lens model...")
with torch.inference_mode():
    tl_logits = tl_model(tl_inputs)[:, -1, :]

tl_next_token = tl_tokenizer.decode(tl_logits.argmax(dim=-1)[0])
print(f"Transformer Lens model next token: {repr(tl_next_token)}")

# Compare logits directly
print(f"\nLogits comparison:")
print(f"Logits shapes - HF: {hf_logits.shape}, TL: {tl_logits.shape}")
print(f"Logits are close (atol=1e-4): {torch.allclose(hf_logits, tl_logits, atol=1e-4)}")
print(f"Max absolute difference: {torch.max(torch.abs(hf_logits - tl_logits)).item():.6f}")
print(f"Mean absolute difference: {torch.mean(torch.abs(hf_logits - tl_logits)).item():.6f}")
print(f"Next tokens match: {hf_next_token == tl_next_token}")
```

Outputs:
```bash
Loading HuggingFace Transformers model...
'<|endoftext|><|user|>\nWhen John and Mary went to the shops, John gave the bag to\n<|assistant|>\n'
Running inference with HuggingFace model...
HuggingFace model next token: 'Mary'

Loading Transformer Lens model...
Loaded pretrained model allenai/OLMo-2-0425-1B-Instruct into HookedTransformer
'<|endoftext|><|user|>\nWhen John and Mary went to the shops, John gave the bag to\n<|assistant|>\n'
Running inference with Transformer Lens model...
Transformer Lens model next token: 'Mary'

Logits comparison:
Logits shapes - HF: torch.Size([1, 100352]), TL: torch.Size([1, 100352])
Logits are close (atol=1e-4): True
Max absolute difference: 0.000041
Mean absolute difference: 0.000007
Next tokens match: True
```

Please let me know if there's anything else I can do to help! 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->